### PR TITLE
Update to undertow-2.2.24.Final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -238,7 +238,7 @@ lazy val mdoc = project
       "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
       "io.methvin" % "directory-watcher" % "0.18.0",
       // live reload
-      "io.undertow" % "undertow-core" % "2.2.20.Final",
+      "io.undertow" % "undertow-core" % "2.2.24.Final",
       "org.jboss.xnio" % "xnio-nio" % "3.8.8.Final",
       "org.slf4j" % "slf4j-api" % "2.0.7",
       "com.geirsson" %% "metaconfig-typesafe-config" % V.metaconfig,


### PR DESCRIPTION
We're getting critical security alerts on CVE-2022-4492 for projects that use mdoc.  I can't imagine how mdoc uses Undertow in the dangerous fashion (it's related to TLS), but this upgrade would reduce a lot of nuisance alerts.

A newer version was reverted in #716, but this appears to still be built with Java 8.